### PR TITLE
feature: 链接到树莓娘介绍主页

### DIFF
--- a/src/components/headers.vue
+++ b/src/components/headers.vue
@@ -190,6 +190,11 @@ export default defineComponent({
           key: 'wiki',
           icon:renderIcon(DnsServices)
         },
+        {
+          label: "数媒娘主页",
+          key: 'berrychan',
+          icon:renderIcon(DnsServices)
+        },
       ],
       options2:[
         {
@@ -283,7 +288,8 @@ export default defineComponent({
         wiki:'https://wiki.bitnp.net',
         address:'common-links',
         PCcommands:'https://docs.qq.com/aio/DZm5ZRmJzd2ZpVkx5',
-        about:'about-us'
+        about:'about-us',
+        berrychan:'https://hjl12345.github.io/'
       }
       //pollyfill
       if (map[key].indexOf('http')!=-1)window.open(map[key]);


### PR DESCRIPTION
在原有的网协主页的顶部菜单栏中添加了一个新的外部链接，链接到一个网协吉祥物-树莓娘的介绍主页。
该主页目前部署在https://hjl12345.github.io/ ，提供了预览树莓娘Live2D形象的功能。